### PR TITLE
Default options to empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 import MemoryFileSystem from 'memory-fs'
 import evalAsModule from 'eval-as-module'
 
-const middlewareCreator = (compiler, options) => {
+const middlewareCreator = (compiler, options = {}) => {
   // the state, false: bundle invalid, true: bundle valid
   let state = false
   let queue = []


### PR DESCRIPTION
Or 
```js
  const watchOptions = {
    aggregateTimeout: 200,
    ...options.watchOptions,
  }
```

will throw an error (`Cannot read property 'watchOptions' of undefined`)